### PR TITLE
Feat/add stores to answer

### DIFF
--- a/src/components/inputs/AnswerButton.tsx
+++ b/src/components/inputs/AnswerButton.tsx
@@ -1,3 +1,5 @@
+import { userAnswer } from "@/stores/userAnswerStores";
+
 const AnswerButton = ({
   text,
   attribute,
@@ -8,6 +10,10 @@ const AnswerButton = ({
   const handleClick = () => {
     // TODO: Implement stores
     console.log(`You clicked the ${attribute} button!`);
+
+    const currentScoreStr = userAnswer.get()[attribute] || "0";
+    const currentScore = parseInt(currentScoreStr, 10);
+    userAnswer.setKey(attribute, (currentScore + 1).toString());
   };
 
   return (

--- a/src/stores/userAnswerStores.ts
+++ b/src/stores/userAnswerStores.ts
@@ -1,0 +1,6 @@
+import { persistentMap } from "@nanostores/persistent";
+
+export const userAnswer = persistentMap<Record<string, string>>(
+  "attribute:",
+  {},
+);


### PR DESCRIPTION
### **feat: add userAnswerStores and implement score storage**

#### **Changes**
- **src/stores/userAnswerStores.ts**
  - Added a new persistent store `userAnswer` using Nano Stores Persistent. This store tracks and stores scores for each attribute as strings.
  
- **src/components/inputs/AnswerButton.tsx**
  - Implemented the logic to retrieve the current score for the clicked attribute, increment it by 1, and update the `userAnswer` store accordingly.
